### PR TITLE
Fix ssl policy flag checks

### DIFF
--- a/src/main/csharp/Transport/Tcp/SslTransport.cs
+++ b/src/main/csharp/Transport/Tcp/SslTransport.cs
@@ -177,7 +177,7 @@ namespace Apache.NMS.ActiveMQ.Transport.Tcp
             }
 
             Tracer.WarnFormat("Certificate error: {0}", sslPolicyErrors.ToString());
-            if(sslPolicyErrors == SslPolicyErrors.RemoteCertificateChainErrors)
+            if((sslPolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) > 0)
             {
                 Tracer.Error("Chain Status errors: ");
                 foreach( X509ChainStatus status in chain.ChainStatus )
@@ -186,11 +186,11 @@ namespace Apache.NMS.ActiveMQ.Transport.Tcp
                     Tracer.Error("*** Chain Status information: " + status.StatusInformation);
                 }
             }
-            else if(sslPolicyErrors == SslPolicyErrors.RemoteCertificateNameMismatch)
+            else if((sslPolicyErrors & SslPolicyErrors.RemoteCertificateNameMismatch) > 0)
             {
                 Tracer.Error("Mismatch between Remote Cert Name.");
             }
-            else if(sslPolicyErrors == SslPolicyErrors.RemoteCertificateNotAvailable)
+            else if((sslPolicyErrors & SslPolicyErrors.RemoteCertificateNotAvailable) > 0)
             {
                 Tracer.Error("The Remote Certificate was not Available.");
             }


### PR DESCRIPTION
SslPolicyErrors is a bit field, not a vanilla enumeration. SslTransport users (e.g. using client authentication) could receive misleading errors if multiple SSL policy errors are present.

Due to .NET 2.0 support, use of [.HasFlag](https://msdn.microsoft.com/en-us/library/system.enum.hasflag.aspx) is out.