### PR TITLE
Enhancement: Support for client cert load via raw bytes

### DIFF
--- a/src/main/csharp/Transport/Tcp/SslTransport.cs
+++ b/src/main/csharp/Transport/Tcp/SslTransport.cs
@@ -30,6 +30,7 @@ namespace Apache.NMS.ActiveMQ.Transport.Tcp
         private string clientCertSubject;
         private string clientCertFilename;
         private string clientCertPassword;
+        private string clientCertBytes;
         private string brokerCertFilename;
         private string keyStoreName;
         private string keyStoreLocation;
@@ -74,6 +75,12 @@ namespace Apache.NMS.ActiveMQ.Transport.Tcp
         {
             get { return this.clientCertFilename; }
             set { this.clientCertFilename = value; }
+        }
+
+        public string ClientCertBytes
+        {
+            get { return this.clientCertBytes; }
+            set { this.clientCertBytes = value; }
         }
 
         /// <summary>
@@ -286,6 +293,15 @@ namespace Apache.NMS.ActiveMQ.Transport.Tcp
             {
                 Tracer.Debug("Attempting to load Client Certificate from file := " + this.clientCertFilename);
                 X509Certificate2 certificate = new X509Certificate2(this.clientCertFilename, this.clientCertPassword);
+                Tracer.Debug("Loaded Client Certificate := " + certificate.ToString());
+
+                collection.Add(certificate);
+            }
+            else if(!String.IsNullOrEmpty(this.clientCertBytes))
+            {
+                Tracer.Debug("Attempting to load Client Certificate from bytes provided");
+                var certBytes = Convert.FromBase64String(this.clientCertBytes);
+                X509Certificate2 certificate = new X509Certificate2(certBytes, this.clientCertPassword);
                 Tracer.Debug("Loaded Client Certificate := " + certificate.ToString());
 
                 collection.Add(certificate);

--- a/src/main/csharp/Transport/Tcp/SslTransportFactory.cs
+++ b/src/main/csharp/Transport/Tcp/SslTransportFactory.cs
@@ -28,6 +28,7 @@ namespace Apache.NMS.ActiveMQ.Transport.Tcp
         private string clientCertSubject;
         private string clientCertFilename;
         private string clientCertPassword;
+        private string clientCertBytes;
         private string brokerCertFilename;
         private string keyStoreName;
         private string keyStoreLocation;
@@ -61,6 +62,12 @@ namespace Apache.NMS.ActiveMQ.Transport.Tcp
             get { return this.clientCertPassword; }
             set { this.clientCertPassword = value; }
         }        
+
+        public string ClientCertBytes
+        {
+            get { return this.clientCertBytes; }
+            set { this.clientCertBytes = value; }
+        }
 
         public string BrokerCertFilename
         {
@@ -100,6 +107,7 @@ namespace Apache.NMS.ActiveMQ.Transport.Tcp
             transport.ClientCertSubject = HttpUtility.UrlDecode(this.clientCertSubject);
             transport.ClientCertFilename = this.clientCertFilename;
             transport.ClientCertPassword = this.clientCertPassword;
+            transport.ClientCertBytes = HttpUtility.UrlDecode(this.clientCertBytes);
             transport.BrokerCertFilename = this.brokerCertFilename;
             transport.ServerName = this.serverName;
             transport.KeyStoreLocation = this.keyStoreLocation;


### PR DESCRIPTION
Client certificate bundles can be specified either via file or subject (for lookup in the certificate store). In some scenarios, neither of these are practical.

This PR wires up a new parameter, `clientCertBytes=<url encoded base64 string>`, for use during construction (e.g. via `NMSConnectionFactory`) to allow specification of client certificate bundle in-memory.
