### PR TITLE
Fix exception when creating session via NetTxConnectionFactory - pars…

### DIFF
--- a/src/main/csharp/NetTxConnection.cs
+++ b/src/main/csharp/NetTxConnection.cs
@@ -96,6 +96,10 @@ namespace Apache.NMS.ActiveMQ
 
         private static Guid GuidFromId(string id)
         {
+            Guid result;
+            if (Guid.TryParse(id, out result))
+                return result;
+
             MatchCollection matches = Regex.Matches(id, @"(\d+)-(\d+)-(\d+):(\d+)$");
             if(0 == matches.Count)
             {


### PR DESCRIPTION
…ing Guid string in NetTxConnection

Without the change I have to use workaround:
```
           var factory = new NetTxConnectionFactory(ConnectUri);

            using (var connection = factory.CreateNetTxConnection("admin", "***"))
            {
                connection.Start();
                // work around - 2 lines below; without it connection.CreateSession() throws exception
                Guid brokerGuid = Guid.Parse(((Connection)connection).ResourceManagerId);
                ((NetTxConnection) connection).ConfiguredResourceManagerId = brokerGuid;

                using (var session = connection.CreateSession(AcknowledgementMode.Transactional))
            }

```