### PR TITLE
Added initialization for ssl properties

### DIFF
--- a/src/main/csharp/Transport/Tcp/SslTransportFactory.cs
+++ b/src/main/csharp/Transport/Tcp/SslTransportFactory.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Web;
 using System.Net.Sockets;
+using System.Configuration;
 
 namespace Apache.NMS.ActiveMQ.Transport.Tcp
 {
@@ -36,6 +37,15 @@ namespace Apache.NMS.ActiveMQ.Transport.Tcp
         
         public SslTransportFactory() : base()
         {
+	    this.ClientCertSubject = HttpUtility.UrlDecode(ConfigurationManager.AppSettings["ClientCertSubject"]);
+            this.ClientCertFilename = ConfigurationManager.AppSettings["ClientCertFilename"];
+            this.ClientCertPassword = ConfigurationManager.AppSettings["ClientCertPassword"];
+            this.BrokerCertFilename = ConfigurationManager.AppSettings["BrokerCertFilename"];
+            this.ServerName = ConfigurationManager.AppSettings["ServerName"];
+            this.KeyStoreLocation = ConfigurationManager.AppSettings["KeyStoreLocation"];
+            this.KeyStoreName = ConfigurationManager.AppSettings["KeyStoreName"];
+            this.AcceptInvalidBrokerCert = ConfigurationManager.AppSettings["AcceptInvalidBrokerCert"] == "true";
+            this.SslProtocol = ConfigurationManager.AppSettings["SslProtocol"];
         }
 
         public string ServerName


### PR DESCRIPTION
Added initialization for ssl properties from .config file. 
We tryed to use ssl connection for our ActiveMQ instance and had some trouble with exception message like "SSPI call failed". When I inherited by SslTransportFactory and set SslProtocol param to "Tls12" everything became OK. I think the good idea settings all properties from configuration.
Pls look that pull request carefully, because I wrote changes not in ide.