### PR TITLE
AMQNET-665 - Fix compression compatibility

### DIFF
--- a/src/CompressionPolicy.cs
+++ b/src/CompressionPolicy.cs
@@ -16,7 +16,8 @@
  */
 
 using System.IO;
-using System.IO.Compression;
+using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
+
 
 namespace Apache.NMS.ActiveMQ
 {
@@ -24,12 +25,12 @@ namespace Apache.NMS.ActiveMQ
     {
         public Stream CreateCompressionStream(Stream data)
         {
-            return new GZipStream(data, CompressionMode.Compress);
+            return new DeflaterOutputStream(data);
         }
 
         public Stream CreateDecompressionStream(Stream data)
         {
-            return new GZipStream(data, CompressionMode.Decompress);
+            return new InflaterInputStream(data);
         }
 
         public object Clone()

--- a/src/nms-openwire.csproj
+++ b/src/nms-openwire.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <RootNamespace>Apache.NMS.ActiveMQ</RootNamespace>
     <AssemblyName>Apache.NMS.ActiveMQ</AssemblyName>
     <Version>1.8.0</Version>
@@ -42,6 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="Apache.NMS" Version="1.8.0" />
+    <PackageReference Include="SharpZipLib" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
Fix the known regression caused in removing IonicZlib which was at the time of supporting .net std not maintained,

An alternative has now been found SharpZibLib.
Unfortunately it does mean the minimum supported framework version now has to bump to 4.5