### PR TITLE
AMQNET-572 - Fix for NMS failover/TLS bug, by saving an Ssl context

### DIFF
--- a/src/Transport/Failover/FailoverTransport.cs
+++ b/src/Transport/Failover/FailoverTransport.cs
@@ -90,6 +90,7 @@ namespace Apache.NMS.ActiveMQ.Transport.Failover
 	 	private bool priorityBackup = false;
     	private List<Uri> priorityList = new List<Uri>();
     	private bool priorityBackupAvailable = false;
+        private String sslProtocol = null;
 
 		// Not Sure how to work these back in with all the changes.
 		//private int asyncTimeout = 45000;

--- a/src/Transport/Tcp/SslContext.cs
+++ b/src/Transport/Tcp/SslContext.cs
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace Apache.NMS.ActiveMQ.Transport.Tcp
+{
+    class SslContext
+    {
+        private String sslProtocol;
+
+        public SslContext() : this("Tls")
+        {
+        }
+
+        public SslContext(String protocol)
+        {
+            this.sslProtocol = protocol;
+        }
+
+        public String SslProtocol
+        {
+            get { return this.sslProtocol; }
+            set { this.sslProtocol = value; }
+        }
+
+        [ThreadStatic]
+        static private SslContext current;
+
+        static public SslContext GetCurrent()
+        {
+            if (current == null)
+            {
+                current = new SslContext();
+            }
+            return current;
+        }
+
+        static public void SetCurrent(SslContext context)
+        {
+            current = context;
+        }
+    }
+}

--- a/src/Transport/Tcp/SslTransportFactory.cs
+++ b/src/Transport/Tcp/SslTransportFactory.cs
@@ -97,6 +97,16 @@ namespace Apache.NMS.ActiveMQ.Transport.Tcp
             Tracer.Debug("Creating new instance of the SSL Transport.");
 			SslTransport transport = new SslTransport(location, socket, wireFormat);
 
+            if (this.sslProtocol == null)
+            {
+                this.sslProtocol = SslContext.GetCurrent().SslProtocol;
+            }
+            else
+            {
+                SslContext.GetCurrent().SslProtocol = this.sslProtocol;
+            }
+            Tracer.DebugFormat("SslProtocol: {0}", this.sslProtocol);
+            
             transport.ClientCertSubject = HttpUtility.UrlDecode(this.clientCertSubject);
             transport.ClientCertFilename = this.clientCertFilename;
             transport.ClientCertPassword = this.clientCertPassword;


### PR DESCRIPTION
Note this is simply a sort out of the PR https://github.com/apache/activemq-nms-openwire/pull/3/files