### PR TITLE
Fix infinite loop on BrokerException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ build/
 package/
 nms.sln.DotSettings.user
 tools/
+
+.DS_store

--- a/src/Connection.cs
+++ b/src/Connection.cs
@@ -1018,7 +1018,7 @@ namespace Apache.NMS.ActiveMQ
 
                                                 throw exception;
                                             }
-                                            else if(exception is InvalidClientIDException)
+                                            else if(exception is InvalidClientIDException || exception is BrokerException)
                                             {
                                                 // This is non-recoverable.
                                                 // Shutdown the transport connection, and re-create it, but don't start it.
@@ -1034,6 +1034,7 @@ namespace Apache.NMS.ActiveMQ
                                 catch(BrokerException)
                                 {
                                     // We Swallow the generic version and throw ConnectionClosedException
+                                    throw;
                                 }
                                 catch(NMSException)
                                 {


### PR DESCRIPTION
This fixes an issue where the client connection will never return back to the calling code because it is stuck in a `while(true)`. This scenario occurs with Failover Transport with two TCP connections where the first broker has reached its max connection limit and the second broker is down or not accepting connections. When a new client tries to connect it will attempt to connect but fail and then get stuck in an endless loop.

This fix breaks that loop and bubbles up the exception.

Sample connection string:

```
activemq:failover:(tcp://localhost:61616,tcp://localhost:61617)?transport.randomize=false&transport.maxReconnectAttempts=3&transport.timeout=5000
```