### PR TITLE
Restrict dependancy to nms api

### DIFF
--- a/src/nms-openwire.csproj
+++ b/src/nms-openwire.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
     <RootNamespace>Apache.NMS.ActiveMQ</RootNamespace>
     <AssemblyName>Apache.NMS.ActiveMQ</AssemblyName>
-    <Version>1.8.0</Version>
+    <Version>1.8.1</Version>
     <Company>Apache Software Foundation</Company>
     <Product>Apache NMS OpenWire</Product>
     <Description>Apache NMS (.Net Standard Messaging Library): Openwire implementation of Apache NMS API</Description>

--- a/src/nms-openwire.csproj
+++ b/src/nms-openwire.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apache.NMS" Version="1.8.0" />
+    <PackageReference Include="Apache.NMS" Version="[1.8.0]"  />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
This addresses versioning issue and confusion that has followed the release of nms.api 2.0.0. 

More context can be found on the mailing list --> https://www.mail-archive.com/dev@activemq.apache.org/msg68064.html