### PR TITLE
update getAllowedProtocol default return value

### DIFF
--- a/src/Transport/Tcp/SslContext.cs
+++ b/src/Transport/Tcp/SslContext.cs
@@ -6,7 +6,7 @@ namespace Apache.NMS.ActiveMQ.Transport.Tcp
     {
         private String sslProtocol;
 
-        public SslContext() : this("Tls")
+        public SslContext() : this("None")
         {
         }
 

--- a/src/Transport/Tcp/SslTransport.cs
+++ b/src/Transport/Tcp/SslTransport.cs
@@ -330,7 +330,7 @@ namespace Apache.NMS.ActiveMQ.Transport.Tcp
                 return (SslProtocols)Enum.Parse(typeof(SslProtocols), SslProtocol, true);
             }
 
-            return SslProtocols.Default;
+            return SslProtocols.None;
         }
     }
 }


### PR DESCRIPTION
If not explicitly using the setter, return SslProtocols.None instead of SslProtocols.Default.  This allows the operating system to choose the best protocol to use, and to block protocols that are not secure.  See MS document at the included link, "default" is not supposed to be used anymore.

https://docs.microsoft.com/en-us/dotnet/api/system.security.authentication.sslprotocols?view=net-6.0

