### PR TITLE
AMQNET-838 ActiveMQ NMS client doesnot support nested parameters for failover transport.

### DIFF
--- a/src/Transport/Failover/FailoverTransportFactory.cs
+++ b/src/Transport/Failover/FailoverTransportFactory.cs
@@ -55,7 +55,15 @@ namespace Apache.NMS.ActiveMQ.Transport.Failover
 			StringDictionary options = compositData.Parameters;
 			FailoverTransport transport = CreateTransport(options);
 			transport.Add(false, compositData.Components);
-			return transport;
+            try
+            {
+                transport.SetNestedExtraQueryOptions(URISupport.CreateQueryString(URISupport.GetProperties(options, "nested.")));
+            }
+            catch (Exception e)
+            {
+				Tracer.Error($"Error in setting nested parameters {e.Message}");
+            }
+            return transport;
 		}
 
 		protected FailoverTransport CreateTransport(StringDictionary parameters)


### PR DESCRIPTION
ActiveMQ NMS client doesnot support nested parameters for failover transport.

Refer "Configuring Nested URI Options" section in https://activemq.apache.org/failover-transport-reference.html 

This is supported for jms client however not for nms client. reference for jms client :
https://github.com/apache/activemq/blob/a2d5d28c1f24d67f57d245003f1d7f96d696dd7c/activemq-client/src/main/java/org/apache/activemq/transport/failover/FailoverTransportFactory.java#L70 https://github.com/apache/activemq/blob/a2d5d28c1f24d67f57d245003f1d7f96d696dd7c/activemq-client/src/main/java/org/apache/activemq/transport/failover/FailoverTransport.java#L1431 https://github.com/apache/activemq/blob/a2d5d28c1f24d67f57d245003f1d7f96d696dd7c/activemq-client/src/main/java/org/apache/activemq/transport/failover/FailoverTransport.java#L1019 https://github.com/apache/activemq/blob/a2d5d28c1f24d67f57d245003f1d7f96d696dd7c/activemq-client/src/main/java/org/apache/activemq/transport/failover/FailoverTransport.java#L1194

As part of this PR , adding support to nested parameters in NMS client for failover transport.

Added unit test to cover this scenario :
![image](https://github.com/apache/activemq-nms-openwire/assets/16554094/edd571cc-81fc-4500-b2a1-d3609dc88a8b)

