### PR TITLE
Fix for AMQNET-727

### DIFF
--- a/src/MessageConsumer.cs
+++ b/src/MessageConsumer.cs
@@ -1293,8 +1293,6 @@ namespace Apache.NMS.ActiveMQ
 
             this.deliveredCounter++;
 
-            using (await this.deliveredMessagesLock.LockAsync().Await())
-            {
 
                 MessageAck oldPendingAck = pendingAck;
 
@@ -1338,7 +1336,6 @@ namespace Apache.NMS.ActiveMQ
                     this.pendingAck = null;
                     this.deliveredCounter = 0;
                     this.additionalWindowSize = 0;
-                }
             }
         }
 

--- a/src/MessageConsumer.cs
+++ b/src/MessageConsumer.cs
@@ -1251,15 +1251,11 @@ namespace Apache.NMS.ActiveMQ
                 }
                 else if(IsClientAcknowledge || IsIndividualAcknowledge)
                 {
-                    bool messageAckedByConsumer = false;
 
                     using(await this.deliveredMessagesLock.LockAsync().Await())
                     {
-                        messageAckedByConsumer = this.deliveredMessages.Contains(dispatch);
-                    }
+                        if (this.deliveredMessages.Contains(dispatch))
 
-                    if(messageAckedByConsumer)
-                    {
                         await AckLaterAsync(dispatch, AckType.DeliveredAck).Await();
                     }
                 }


### PR DESCRIPTION
Fix for the thread sync issues as reported in AMQNET-727.
Note that the first part of the fix (in DeliverAcks), comes from this fix in the Java client:
https://github.com/apache/activemq/commit/c02bc648460059b6dbc201fa21b7ee0ce2445082

The 2nd part of the fix (in AfterMessageIsConsumedAsync), is just a slight change to make the call to AckLaterAsync occur while the lock is held.