### PR TITLE
Fix for AMQNET-727

### DIFF
--- a/src/MessageConsumer.cs
+++ b/src/MessageConsumer.cs
@@ -1255,8 +1255,9 @@ namespace Apache.NMS.ActiveMQ
                     using(await this.deliveredMessagesLock.LockAsync().Await())
                     {
                         if (this.deliveredMessages.Contains(dispatch))
-
-                        await AckLaterAsync(dispatch, AckType.DeliveredAck).Await();
+                        {
+                            await AckLaterAsync(dispatch, AckType.DeliveredAck).Await();
+                        }
                     }
                 }
                 else

--- a/src/MessageConsumer.cs
+++ b/src/MessageConsumer.cs
@@ -662,12 +662,12 @@ namespace Apache.NMS.ActiveMQ
 
             if(this.deliveringAcks.CompareAndSet(false, true))
             {
-                if(this.IsAutoAcknowledgeEach)
+                using (this.deliveredMessagesLock.Lock())
                 {
-                    using(this.deliveredMessagesLock.Lock())
+                    if (this.IsAutoAcknowledgeEach)
                     {
                         ack = MakeAckForAllDeliveredMessages(AckType.ConsumedAck);
-                        if(ack != null)
+                        if (ack != null)
                         {
                             Tracer.DebugFormat("Consumer[{0}] DeliverAcks clearing the Dispatch list", ConsumerId);
                             this.deliveredMessages.Clear();
@@ -679,11 +679,11 @@ namespace Apache.NMS.ActiveMQ
                             this.pendingAck = null;
                         }
                     }
-                }
-                else if(pendingAck != null && pendingAck.AckType == (byte) AckType.ConsumedAck)
-                {
-                    ack = pendingAck;
-                    pendingAck = null;
+                    else if (pendingAck != null && pendingAck.AckType == (byte)AckType.ConsumedAck)
+                    {
+                        ack = pendingAck;
+                        pendingAck = null;
+                    }
                 }
 
                 if(ack != null)
@@ -1251,15 +1251,11 @@ namespace Apache.NMS.ActiveMQ
                 }
                 else if(IsClientAcknowledge || IsIndividualAcknowledge)
                 {
-                    bool messageAckedByConsumer = false;
 
                     using(await this.deliveredMessagesLock.LockAsync().Await())
                     {
-                        messageAckedByConsumer = this.deliveredMessages.Contains(dispatch);
-                    }
+                        if (this.deliveredMessages.Contains(dispatch))
 
-                    if(messageAckedByConsumer)
-                    {
                         await AckLaterAsync(dispatch, AckType.DeliveredAck).Await();
                     }
                 }


### PR DESCRIPTION
Fix for the thread sync issues as reported in AMQNET-727.
Note that the first part of the fix (in DeliverAcks), comes from this fix in the Java client:
https://github.com/apache/activemq/commit/c02bc648460059b6dbc201fa21b7ee0ce2445082

The 2nd part of the fix (in AfterMessageIsConsumedAsync), is just a slight change to make the call to AckLaterAsync occur while the lock is held.