### PR TITLE
Replace SharpZipLib with System.IO.Compression.DeflateStream

### DIFF
--- a/src/CompressionPolicy.cs
+++ b/src/CompressionPolicy.cs
@@ -16,7 +16,6 @@
  */
 
 using System.IO;
-using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
 
 
 namespace Apache.NMS.ActiveMQ
@@ -25,12 +24,12 @@ namespace Apache.NMS.ActiveMQ
     {
         public Stream CreateCompressionStream(Stream data)
         {
-            return new DeflaterOutputStream(data);
+            return new System.IO.Compression.DeflateStream(data, System.IO.Compression.CompressionMode.Compress);
         }
 
         public Stream CreateDecompressionStream(Stream data)
         {
-            return new InflaterInputStream(data);
+            return new System.IO.Compression.DeflateStream(data, System.IO.Compression.CompressionMode.Decompress);
         }
 
         public object Clone()

--- a/src/nms-openwire.csproj
+++ b/src/nms-openwire.csproj
@@ -34,7 +34,6 @@
   
   <ItemGroup>
     <PackageReference Include="Apache.NMS" Version="2.2.0" />
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
SharpZipLib  was needed for NET35, but project can no longer compile on that target-platform. Thus just use the compression-logic included with standard .NET